### PR TITLE
Feature/travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: node_js
+
+node_js:
+   - node # will use latest node
+
+before_script: # commands to run before the build step
+   - npm install -g --silent @angular/cli
+
+script: # the build step
+   - ng build --prod
+
+notifications:
+  email: # only receive email when the build status changes (someone broke the build!) 
+    on_failure: change
+    on_success: change

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+dist: trusty
+sudo: false
+
 addons:
   chrome: stable
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ before_script: # commands to run before the build step
    - npm install -g --silent @angular/cli
 
 script: # the build step
+   - ng test --single-run --no-progress
    - ng build --prod
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_script: # commands to run before the build step
    - npm install -g --silent @angular/cli
 
 script: # the build step
-   - ng test --single-run --no-progress
+   - ng test --single-run --no-progress --browsers ChromeHeadless
    - ng build --prod
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
+addons:
+  chrome: stable
+
 language: node_js
 
 node_js:
    - node # will use latest node
-
-addons:
-  chrome: stable
 
 before_script: # commands to run before the build step
    - npm install -g --silent @angular/cli

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ language: node_js
 node_js:
    - node # will use latest node
 
+addons:
+  chrome: stable
+
 before_script: # commands to run before the build step
    - npm install -g --silent @angular/cli
 


### PR DESCRIPTION
Introduce integration with travis as a CI server.
Travis will run the CI build for the blog on every commit.
Currently the CI build runs the unit tests, then runs the prod build.